### PR TITLE
Harden Windows core-pro smoke setup

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -72,12 +72,27 @@ ctest --test-dir build --output-on-failure
 bash tools/run_core_pro_smoke.sh
 ```
 
+Windows ネイティブでは、使用する Hakoniwa Core 設定を明示することを推奨します。
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File tools/run_core_pro_smoke.ps1 `
+  -GodotBin C:\path\to\Godot_console.exe `
+  -HakoConfigPath C:\path\to\cpp_core_config.json
+```
+
 Windows / WSL2:
 
 ```bash
 bash tools/run_core_pro_smoke_wsl.sh \
-  --godot-bin /mnt/c/path/to/Godot_console.exe
+  --godot-bin /mnt/c/path/to/Godot_console.exe \
+  --hako-config-path /mnt/c/path/to/cpp_core_config.json
 ```
+
+`-HakoConfigPath` / `--hako-config-path` は後方互換のため必須にはしていません。未指定の場合、runner は現在の `HAKO_CONFIG_PATH` を継承するか、環境変数がなければ Hakoniwa Core のデフォルト設定を使い、その選択を WARNING で表示します。smoke test がどの core 設定を参照しているかを明示的に確認してください。
+
+Windows runner は test project の `addons` も起動前に確認します。Git for Windows で POSIX symlink が通常ファイルとして checkout されていた場合や `addons` が存在しない場合は、repo root の `addons/` を実ディレクトリとしてコピーして正規化します。正常な symbolic link はそのまま使用します。
+
+`core_pro_smoke` では Godot の `--quit` を付けません。このテストは conductor と start / stop / reset / restart / step を複数 frame にわたって実行し、正常完了時に GDScript 自身が `HAKO_CORE_SMOKE_OK` を出力して `get_tree().quit(0)` します。
 
 成功条件:
 

--- a/tools/run_core_pro_smoke.ps1
+++ b/tools/run_core_pro_smoke.ps1
@@ -4,11 +4,11 @@ param(
     [string]$ProjectDir = "",
     [string]$BuildDir = "",
     [string]$Configuration = "Release",
+    [string]$HakoConfigPath = "",
     [int]$WaitSec = 1,
     [int]$ConductorDeltaUsec = 10000,
     [int]$ConductorMaxDelayUsec = 20000,
     [switch]$SyncAddons,
-    [switch]$QuitAfterRun,
     [switch]$KeepConductor
 )
 
@@ -41,24 +41,55 @@ if (-not (Test-Path -LiteralPath $ConductorExe -PathType Leaf)) {
     throw "Windows conductor runner not found: $ConductorExe"
 }
 
-if ($SyncAddons) {
+function Ensure-ProjectAddons {
     if (-not (Test-Path -LiteralPath $RepoAddonsDir -PathType Container)) {
         throw "Repository addons directory not found: $RepoAddonsDir"
     }
-    $SkipSyncBecauseSymlink = $false
+
     if (Test-Path -LiteralPath $ProjectAddonsDir) {
         $ProjectAddonsItem = Get-Item -LiteralPath $ProjectAddonsDir -Force
         if ($ProjectAddonsItem.LinkType -eq "SymbolicLink") {
-            $SkipSyncBecauseSymlink = $true
+            Write-Host "[run-core-pro-smoke.ps1] addons uses repository symlink: $ProjectAddonsDir"
+            return
         }
-        else {
-            Remove-Item -LiteralPath $ProjectAddonsDir -Recurse -Force
-        }
+
+        Write-Warning "Project addons path is not a symbolic link. Replacing it with a copy of the repository addons directory: $ProjectAddonsDir"
+        Remove-Item -LiteralPath $ProjectAddonsDir -Recurse -Force
     }
-    if (-not $SkipSyncBecauseSymlink) {
-        New-Item -ItemType Directory -Force -Path $ProjectAddonsDir | Out-Null
-        Copy-Item -Path (Join-Path $RepoAddonsDir "*") -Destination $ProjectAddonsDir -Recurse -Force
+    else {
+        Write-Warning "Project addons path is missing. Creating a copy of the repository addons directory: $ProjectAddonsDir"
     }
+
+    New-Item -ItemType Directory -Force -Path $ProjectAddonsDir | Out-Null
+    Copy-Item -Path (Join-Path $RepoAddonsDir "*") -Destination $ProjectAddonsDir -Recurse -Force
+}
+
+if ($SyncAddons) {
+    Write-Warning "-SyncAddons is no longer required; addons are validated and normalized automatically on Windows."
+}
+Ensure-ProjectAddons
+
+$HadOriginalHakoConfigPath = Test-Path Env:HAKO_CONFIG_PATH
+$OriginalHakoConfigPath = $env:HAKO_CONFIG_PATH
+$OverrideHakoConfigPath = $false
+
+if (-not [string]::IsNullOrWhiteSpace($HakoConfigPath)) {
+    if (-not (Test-Path -LiteralPath $HakoConfigPath -PathType Leaf)) {
+        throw "Hakoniwa Core config not found: $HakoConfigPath"
+    }
+    $ResolvedHakoConfigPath = (Resolve-Path -LiteralPath $HakoConfigPath).Path
+    $env:HAKO_CONFIG_PATH = $ResolvedHakoConfigPath
+    $OverrideHakoConfigPath = $true
+    Write-Host "[run-core-pro-smoke.ps1] using explicit HAKO_CONFIG_PATH=$ResolvedHakoConfigPath"
+}
+elseif (-not [string]::IsNullOrWhiteSpace($env:HAKO_CONFIG_PATH)) {
+    Write-Warning "-HakoConfigPath was not specified. Inheriting HAKO_CONFIG_PATH=$($env:HAKO_CONFIG_PATH). Confirm that this config belongs to the Hakoniwa runtime used by this smoke test."
+    if (-not (Test-Path -LiteralPath $env:HAKO_CONFIG_PATH -PathType Leaf)) {
+        Write-Warning "The inherited HAKO_CONFIG_PATH does not point to an existing file: $($env:HAKO_CONFIG_PATH)"
+    }
+}
+else {
+    Write-Warning "-HakoConfigPath was not specified and HAKO_CONFIG_PATH is unset. Hakoniwa Core will use its default configuration path."
 }
 
 $ConductorArguments = @(
@@ -66,20 +97,20 @@ $ConductorArguments = @(
     "--max-delay-usec", $ConductorMaxDelayUsec
 )
 
-Write-Host "[run-core-pro-smoke.ps1] starting conductor"
-$ConductorProcess = Start-Process `
-    -FilePath $ConductorExe `
-    -ArgumentList $ConductorArguments `
-    -PassThru `
-    -WindowStyle Hidden
-
+$ConductorProcess = $null
 try {
+    Write-Host "[run-core-pro-smoke.ps1] starting conductor"
+    $ConductorProcess = Start-Process `
+        -FilePath $ConductorExe `
+        -ArgumentList $ConductorArguments `
+        -PassThru `
+        -WindowStyle Hidden
+
     Start-Sleep -Seconds $WaitSec
 
+    # core_pro_smoke drives an asynchronous multi-frame lifecycle and quits itself
+    # after emitting HAKO_CORE_SMOKE_OK. Do not pass Godot's --quit flag here.
     $GodotArguments = @("--headless", "--path", $ProjectDir)
-    if ($QuitAfterRun) {
-        $GodotArguments += "--quit"
-    }
 
     Write-Host "[run-core-pro-smoke.ps1] launching Godot"
     $StdoutPath = [System.IO.Path]::GetTempFileName()
@@ -130,5 +161,14 @@ try {
 finally {
     if (-not $KeepConductor -and $ConductorProcess -and -not $ConductorProcess.HasExited) {
         Stop-Process -Id $ConductorProcess.Id -Force -ErrorAction SilentlyContinue
+    }
+
+    if ($OverrideHakoConfigPath) {
+        if ($HadOriginalHakoConfigPath) {
+            $env:HAKO_CONFIG_PATH = $OriginalHakoConfigPath
+        }
+        else {
+            Remove-Item Env:HAKO_CONFIG_PATH -ErrorAction SilentlyContinue
+        }
     }
 }

--- a/tools/run_core_pro_smoke_wsl.sh
+++ b/tools/run_core_pro_smoke_wsl.sh
@@ -7,12 +7,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 godot_bin=""
 project_dir=""
 build_dir=""
+hako_config_path=""
 config="Release"
 wait_sec="1"
 delta_usec="10000"
 max_delay_usec="20000"
-quit_after_run="false"
-sync_addons="true"
 keep_conductor="false"
 
 usage() {
@@ -24,12 +23,11 @@ Options:
   --godot-bin PATH
   --project-dir PATH
   --build-dir PATH
+  --hako-config-path PATH
   --config Debug|Release
   --wait-sec N
   --conductor-delta-usec N
   --conductor-max-delay-usec N
-  --quit
-  --no-sync-addons
   --keep-conductor
 EOF
 }
@@ -63,6 +61,10 @@ while [[ $# -gt 0 ]]; do
       build_dir="$(to_windows_path "$2")"
       shift 2
       ;;
+    --hako-config-path)
+      hako_config_path="$(to_windows_path "$2")"
+      shift 2
+      ;;
     --config)
       config="$2"
       shift 2
@@ -80,12 +82,12 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --quit)
-      quit_after_run="true"
-      shift
+      echo "--quit is not supported for core_pro_smoke. The Godot test runs a multi-frame lifecycle and quits itself after HAKO_CORE_SMOKE_OK." >&2
+      exit 2
       ;;
     --no-sync-addons)
-      sync_addons="false"
-      shift
+      echo "--no-sync-addons is no longer supported. The Windows runner validates and normalizes the project addons path automatically." >&2
+      exit 2
       ;;
     --keep-conductor)
       keep_conductor="true"
@@ -129,12 +131,8 @@ if [[ -n "${build_dir}" ]]; then
   cmd+=(-BuildDir "${build_dir}")
 fi
 
-if [[ "${quit_after_run}" == "true" ]]; then
-  cmd+=(-QuitAfterRun)
-fi
-
-if [[ "${sync_addons}" == "true" ]]; then
-  cmd+=(-SyncAddons)
+if [[ -n "${hako_config_path}" ]]; then
+  cmd+=(-HakoConfigPath "${hako_config_path}")
 fi
 
 if [[ "${keep_conductor}" == "true" ]]; then


### PR DESCRIPTION
## Summary

Harden the Windows `core_pro_smoke` runner against the three environment pitfalls captured in #5 and the corresponding Business Pack Knowledge Candidate.

## Changes

- Normalize the test project's `addons` path automatically on Windows:
  - keep a working symbolic link as-is;
  - replace a plain-file/broken checkout or missing path with a real copy of the repository `addons/` tree.
- Add `-HakoConfigPath` to the PowerShell runner and `--hako-config-path` to the WSL wrapper.
  - explicit paths are validated and used only for the smoke process lifetime;
  - the caller's original `HAKO_CONFIG_PATH` is restored afterwards;
  - when omitted, the runner preserves backward compatibility but warns which inherited/default config will be used.
- Stop exposing Godot `--quit` for `core_pro_smoke`.
  - this smoke test drives start/stop/reset/restart/step across multiple frames and already calls `get_tree().quit(0)` after `HAKO_CORE_SMOKE_OK`;
  - the WSL wrapper rejects the old `--quit` option with an actionable error.
- Document the explicit Windows configuration path, automatic addon normalization, and why `--quit` must not be used for this asynchronous smoke lifecycle.

## Why

The native Windows build itself works, but the smoke workflow could be derailed by Git symlink checkout behavior, an inherited config from another Hakoniwa workspace, or an engine-level quit flag that terminates the multi-frame lifecycle early. The runner should make those assumptions explicit instead of relying on hidden caller state.

## Validation

- `bash -n tools/run_core_pro_smoke_wsl.sh`
- reviewed the PowerShell flow so explicit `HAKO_CONFIG_PATH` is restored in `finally`
- full native Windows runtime re-verification is still required before the Business Pack Knowledge Candidate can set `resolution.verified: true`

Closes #5
